### PR TITLE
Wrap reset and loop body in {}

### DIFF
--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -390,6 +390,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
 
                 if (findwhile && line.indexOf('while') !== -1) {
                   DEBUG && debug('- exit as we found `while`: ' + line); // jshint ignore:line
+                  // TODO: handle while statement in multiple lines
                   line += '}';
                   recompiled.push(line);
                   ignore[lineNum] = true;

--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -137,7 +137,10 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
       // recompile the line with the reset **just** before the actual loop
       // so that we insert in to the correct location (instead of possibly
       // outside the logic
-      return line.slice(0, matchPosition) + ';' + method + '({ line: ' + lineNum + ', reset: true }); ' + line.slice(matchPosition);
+      // wrap reset and loop in a block to avoid one line loop behind
+      // `if (false)`, insert the open brace in this function, and the close
+      // brace after loop close brace.
+      return line.slice(0, matchPosition) + '{;' + method + '({ line: ' + lineNum + ', reset: true }); ' + line.slice(matchPosition);
     };
 
     if (!offset) {
@@ -172,6 +175,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
       var labelMatch = line.match(labelRe) || [];
       var openBrackets = 0;
       var openBraces = 0;
+      var foundLoopEnd = false;
 
       if (labelMatch.length) {
         DEBUG && debug('- label match'); // jshint ignore:line
@@ -276,18 +280,19 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
 
           if (openBrackets === 0 && (character === ';' || character === '{')) {
             // if we're a non-curlies loop, then convert to curlies to get our code inserted
+            // add a close brace after loop to match the open brace before reset
             if (character === ';') {
               if (lineNum !== originalLineNum) {
                 DEBUG && debug('- multiline inline loop'); // jshint ignore:line
                 // affect the compiled line
                 recompiled[originalLineNum] = recompiled[originalLineNum].substring(0, terminator + 1) + '{\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n' + recompiled[originalLineNum].substring(terminator + 1);
-                line += '\n}\n';
+                line += '\n}}\n';
               } else {
                 // simpler
                 DEBUG && debug('- single line inline loop'); // jshint ignore:line
-                line = line.substring(0, terminator + 1) + '{\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n' + line.substring(terminator + 1) + '\n}\n';
+                line = line.substring(0, terminator + 1) + '{\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n' + line.substring(terminator + 1) + '\n}}\n';
               }
-
+              foundLoopEnd = true;
             } else if (character === '{') {
               DEBUG && debug('- multiline with braces'); // jshint ignore:line
               var insert = ';\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n';
@@ -318,9 +323,44 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
               }
             }
 
-            recompiled.push(line);
-
             if (!dofound) {
+              if (foundLoopEnd) {
+                recompiled.push(line);
+                return;
+              }
+
+              DEBUG && debug('searching for closing brace of loop for: ' + line); // jshint ignore:line
+              while (line !== null) {
+                character = line.substr(index, 1);
+
+                DEBUG && debug(index, character, openBraces); // jshint ignore:line
+
+                if (character === '{') {
+                  openBraces++;
+                }
+
+                if (character === '}') {
+                  openBraces--;
+                  if (openBraces === 0) {
+                    DEBUG && debug('outside of loop, add a close brace to: ' + line); // jshint ignore:line
+                    line = line.substring(0, index+1) + '}' + line.substring(index+1);
+                    recompiled.push(line);
+                    ignore[lineNum] = true;
+                    return;
+                  }
+                }
+
+                index++;
+
+                if (index >= line.length) {
+                  recompiled.push(line);
+                  ignore[lineNum] = true;
+                  lineNum++;
+                  line = lines[lineNum];
+                  DEBUG && debug(line); // jshint ignore:line
+                  index = 0;
+                }
+              }
               return;
             } else {
               DEBUG && debug('searching for closing `while` statement for: ' + line); // jshint ignore:line
@@ -350,13 +390,17 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
 
                 if (findwhile && line.indexOf('while') !== -1) {
                   DEBUG && debug('- exit as we found `while`: ' + line); // jshint ignore:line
-                  pushonly[lineNum] = true;
+                  line += '}';
+                  recompiled.push(line);
+                  ignore[lineNum] = true;
                   return;
                 }
 
                 index++;
 
                 if (index === line.length && lineNum < (lines.length-1)) {
+                  recompiled.push(line);
+                  ignore[lineNum] = true;
                   lineNum++;
                   line = lines[lineNum];
                   DEBUG && debug(line); // jshint ignore:line

--- a/test/loop-protect.test.js
+++ b/test/loop-protect.test.js
@@ -44,6 +44,8 @@ var code = {
   notlabels: 'var foo = {\n bar: 1\n };\n \n function doit(i){}\n \n for (var i=0; i<10; i++) {\n doit(i);\n }\n return i;',
   notlabels2: '// Weird:\nfor (var i = 0; i < 10; i++) {}\nreturn i;',
   cs: 'var bar, foo;\n\nfoo = function(i) {\n  return {\n    id: i\n  };\n};\n\nbar = function(i) {\n\n  var j, _i, _results;\n\n  _results = [];\n  for (j = _i = 1; 1 <= i ? _i < i : _i > i; j = 1 <= i ? ++_i : --_i) {\n    _results.push(j);\n  }\n  return _results;\n};',
+  loopbehindif: 'if (false) {for (var i = 1; i--;) {throw Error;}}',
+  badloopbehindif: 'if (false) for (var i = 1; i--;) {throw Error;}',
 };
 
 var spy;
@@ -267,5 +269,17 @@ describe('labels', function () {
     // result = run(compiled);
     // assert(result === 10, 'actual ' + result);
   });
+
+  it('should handle if statement without {}', function() {
+    var c = code.loopbehindif;
+    var compiled = loopProtect(c);
+    assert(compiled !== c);
+    run(compiled);
+
+    c = code.badloopbehindif;
+    compiled = loopProtect(c);
+    assert(compiled !== c);
+    run(compiled);
+  })
 
 });

--- a/test/loop-protect.test.js
+++ b/test/loop-protect.test.js
@@ -58,7 +58,7 @@ function run(code) {
 describe('loop', function () {
   beforeEach(function () {
     spy = sinon.spy(run);
-    loopProtect.debug(false);
+    loopProtect.debug(true);
   });
 
   it('should ignore comments', function () {
@@ -224,7 +224,6 @@ describe('loop', function () {
     // console.log(compiled);
     assert(compiled !== c);
     assert(spy(compiled) === 3);
-
   });
 });
 

--- a/test/loop-protect.test.js
+++ b/test/loop-protect.test.js
@@ -36,6 +36,7 @@ var code = {
   ignorecomments: '\n/**\n * This function handles the click for every button.\n *\n * Using the same function reduces code duplication and makes the\n */\nreturn true;',
   dowhile: 'var x=0;\ndo\n {\n x++;\n } while (x < 3);\nreturn x;',
   dowhilenested: 'var x=0;\n do\n {\n x++;\n var b = 0;\n do {\n b++; \n } while (b < 3);\n } while (x < 3);\nreturn x;',
+  infinitedowhile: 'var x=0;\ndo\n {\n x=0;\n } while (x < 3);\n return x;',
   disabled: '// noprotect\nvar x=0;\ndo\n {\n x++;\n } while (x < 3);\nreturn x;',
   continues: 'var n = 0,\n i = 0,\n j = 0;\n \n outside:\n for (i; i < 10; i += 1) {\n for (j; j < 10; j += 1) {\n if (i === 5 && j === 5) {\n continue outside;\n }\n n += 1;\n }\n }\n \n return n;\n;',
   labelWithComment: 'label:\n// here be a label\n/*\n and there\'s some good examples in the loop - poop\n*/\nfor (var i = 0; i < 10; i++) {\n}\nreturn i;',
@@ -224,6 +225,11 @@ describe('loop', function () {
     // console.log(compiled);
     assert(compiled !== c);
     assert(spy(compiled) === 3);
+
+    c = code.infinitedowhile;
+    compiled = loopProtect(c);
+    assert(compiled !== c);
+    assert(spy(compiled) === 0);
   });
 });
 


### PR DESCRIPTION
This is to fix issue #3, by wrapping the added reset and loop body in another {} we can eliminate the issue. This patch isn't that complete yet, it has a TODO within the `do` loop implementation, wanted to open a pull request and discuss the approach before fixing it.