### PR TITLE
Fix handling of default case and linting errors

### DIFF
--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -26,7 +26,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
   // the standard loops - note that recursive is not supported
   var re = /\b(for|while|do)\b/g;
   var reSingle = /\b(for|while|do)\b/;
-  var labelRe = /\b([a-z_]{1}\w+:)/i;
+  var labelRe = /\b(?!default:)([a-z_]{1}\w+:)/i;
   var comments = /(?:\/\*(?:[\s\S]*?)\*\/)|(?:([\s;])+\/\/(?:.*)$)/gm;
 
   var loopProtect = rewriteLoops;
@@ -141,7 +141,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
       // `if (false)`, insert the open brace in this function, and the close
       // brace after loop close brace.
       return line.slice(0, matchPosition) + '{;' + method + '({ line: ' + lineNum + ', reset: true }); ' + line.slice(matchPosition);
-    };
+    }
 
     if (!offset) {
       offset = 0;
@@ -438,7 +438,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
     DEBUG && debug(''); // jshint ignore:line
 
     return disableLoopProtection ? code : recompiled.join('\n');
-  };
+  }
 
   /**
    * Injected code in to user's code to **try** to protect against infinite

--- a/test/loop-protect.test.js
+++ b/test/loop-protect.test.js
@@ -285,6 +285,6 @@ describe('labels', function () {
     compiled = loopProtect(c);
     assert(compiled !== c);
     run(compiled);
-  })
+  });
 
 });

--- a/test/non-jsbin.test.js
+++ b/test/non-jsbin.test.js
@@ -1,5 +1,5 @@
 'use strict';
-/*global describe:true, it: true, beforeEach: true */
+/*global describe:true, it: true */
 var assert = require('assert');
 var loopProtect = require('../lib/loop-protect');
 
@@ -17,7 +17,7 @@ describe('non-JS Bin use', function () {
     loopProtect.hit = function (line) {
       assert(line === 1, 'Loop found on line ' + line);
       done();
-    }
+    };
 
     var processed = loopProtect(code);
 


### PR DESCRIPTION
It was flagging `default:` as a label previously. Also fixed a couple linting errors while I was at it.