### PR TITLE
Handle curly braces inside comments and strings

### DIFF
--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -275,11 +275,13 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
             }
           }
 
-          if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
+          var openCbInCommentOrString = inCommentOrString(index, lines[lineNum]) && inMultilineComment(lineNum, lines)
+
+          if (character === '{' && !openCbInCommentOrString) {
             openBraces++;
           }
 
-          if (character === '}' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
+          if (character === '}' && !inCommentOrString(index, lines[lineNum]) && !inMultilineComment(lineNum, lines)) {
             openBraces--;
           }
 
@@ -298,7 +300,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
                 line = line.substring(0, terminator + 1) + '{\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n' + line.substring(terminator + 1) + '\n}}\n';
               }
               foundLoopEnd = true;
-            } else if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
+            } else if (character === '{' && !openCbInCommentOrString) {
               DEBUG && debug('- multiline with braces'); // jshint ignore:line
               var insert = ';\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n';
               line = line.substring(0, index + 1) + insert + line.substring(index + 1);
@@ -340,11 +342,11 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
 
                 DEBUG && debug(index, character, openBraces); // jshint ignore:line
 
-                if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
+                if (character === '{' && !inCommentOrString(index, lines[lineNum]) && !inMultilineComment(lineNum, lines)) {
                   openBraces++;
                 }
 
-                if (character === '}' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
+                if (character === '}' && !inCommentOrString(index, lines[lineNum]) && !inMultilineComment(lineNum, lines)) {
                   openBraces--;
                   if (openBraces === 0) {
                     DEBUG && debug('outside of loop, add a close brace to: ' + line); // jshint ignore:line
@@ -375,11 +377,11 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
               while (index < line.length) {
                 character = line.substr(index, 1);
 
-                if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
+                if (character === '{' && !inCommentOrString(index, lines[lineNum]) && !inMultilineComment(lineNum, lines)) {
                   openBraces++;
                 }
 
-                if (character === '}' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
+                if (character === '}' && !inCommentOrString(index, lines[lineNum]) && !inMultilineComment(lineNum, lines)) {
                   openBraces--;
                 }
 

--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -275,11 +275,11 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
             }
           }
 
-          if (character === '{') {
+          if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
             openBraces++;
           }
 
-          if (character === '}') {
+          if (character === '}' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
             openBraces--;
           }
 
@@ -298,7 +298,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
                 line = line.substring(0, terminator + 1) + '{\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n' + line.substring(terminator + 1) + '\n}}\n';
               }
               foundLoopEnd = true;
-            } else if (character === '{') {
+            } else if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
               DEBUG && debug('- multiline with braces'); // jshint ignore:line
               var insert = ';\nif (' + method + '({ line: ' + printLineNumber + ' })) break;\n';
               line = line.substring(0, index + 1) + insert + line.substring(index + 1);
@@ -340,11 +340,11 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
 
                 DEBUG && debug(index, character, openBraces); // jshint ignore:line
 
-                if (character === '{') {
+                if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
                   openBraces++;
                 }
 
-                if (character === '}') {
+                if (character === '}' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
                   openBraces--;
                   if (openBraces === 0) {
                     DEBUG && debug('outside of loop, add a close brace to: ' + line); // jshint ignore:line
@@ -375,11 +375,11 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
               while (index < line.length) {
                 character = line.substr(index, 1);
 
-                if (character === '{') {
+                if (character === '{' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
                   openBraces++;
                 }
 
-                if (character === '}') {
+                if (character === '}' && !inCommentOrString(index, line) && !inMultilineComment(lineNum, lines)) {
                   openBraces--;
                 }
 


### PR DESCRIPTION
The following examples doesn't work:

``` javascript
var counter = 0; 
while (true) { 
counter++; 
// if (true) { 

   if (counter > 10) { 
      break; 
   } 
} 

out.println('hello, World!'); 
```

``` javascript
var counter = 0; 
while (true) { 
counter++; 
   var test = ['{']; 

   if (counter > 10) { 
      break; 
   } 
} 

out.println('hello, World!'); 
```

This commit fixes this problem by checking if curly braces are inside a comment, multiline comment or a string.
