### PR TITLE
Fix two multiline comment scenarios, jshint errors

### DIFF
--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -6,7 +6,7 @@
  * true, preventing the loop from running again.
  */
 
-if (typeof DEBUG === 'undefined') { DEBUG = true; }
+if (typeof DEBUG === 'undefined') { DEBUG = true; } //jshint ignore:line
 
 (function (root, factory) {
   'use strict';
@@ -79,7 +79,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
         }
       }
       j -= 1;
-    } while (j !== 0);
+    } while (j >= 0);
 
     return false;
   }
@@ -95,8 +95,8 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
       }
       if (character === '/' || character === '*') {
         // looks like a comment, go back one to confirm or not
-        --index;
-        if (character === '/') {
+        var prevCharacter = line.substr(index - 1, 1);
+        if (prevCharacter === '/') {
           // we've found a comment, so let's exit and ignore this line
           DEBUG && debug('- exit: part of a comment'); // jshint ignore:line
           return true;

--- a/test/loop-protect.test.js
+++ b/test/loop-protect.test.js
@@ -47,7 +47,8 @@ var code = {
   cs: 'var bar, foo;\n\nfoo = function(i) {\n  return {\n    id: i\n  };\n};\n\nbar = function(i) {\n\n  var j, _i, _results;\n\n  _results = [];\n  for (j = _i = 1; 1 <= i ? _i < i : _i > i; j = 1 <= i ? ++_i : --_i) {\n    _results.push(j);\n  }\n  return _results;\n};',
   loopbehindif: 'if (false) {for (var i = 1; i--;) {throw Error;}}',
   badloopbehindif: 'if (false) for (var i = 1; i--;) {throw Error;}',
-  singlelinemultiline: '/* reverse palinWord doe comparison*/'
+  singlelinemultiline: '/* reverse palinWord doe comparison*/',
+  complexmultiline: '/* This was a tough one for me.\nLet\'s use the Euclidean Algorithm to first get the GCD and\nthen use that to calculate the LCM\nThis below function for obtaining the gcd was posted on StackOverflow by "alex" at\nhttps://stackoverflow.com/questions/17445231/js-how-to-find-the-greatest-common-divisor/.\n*/'
 };
 
 var spy;
@@ -289,10 +290,17 @@ describe('labels', function () {
   });
 
   it('should handle single line "/* comment */"', function() {
-    var c = code.singlelinemultiline
+    var c = code.singlelinemultiline;
     var compiled = loopProtect(c);
     assert(compiled === c);
     run(compiled);
-  })
+  });
+
+  it('should handle complex multiline "/* comment */"', function() {
+    var c = code.complexmultiline;
+    var compiled = loopProtect(c);
+    assert(compiled === c);
+    run(compiled);
+  });
 
 });


### PR DESCRIPTION
Fixes an issue with not appropriately backing up a character to detect comments and with not searching for the start of a multiline comment in line 0. Added a test case that covers both these scenarios.

Also, fixed two jshint errors.