### PR TITLE
fix: use with babel-7

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,8 @@ module.exports = (timeout = 100, extra = null) => {
   }
 
   return ({ types: t, transform }) => {
-    const node = extra ? transform(extra).ast.program.body[0] : null;
+    const node = extra ?
+      transform(extra, { ast: true }).ast.program.body[0] : null;
 
     let callback = null;
     if (t.isExpressionStatement(node)) {


### PR DESCRIPTION
Need to set the [`ast` option](http://babeljs.io/docs/en/next/babel-core#options), as Babel changed [this to default to `false` around beta 41](https://github.com/babel/babel/pull/7436).

Closes #20 